### PR TITLE
📦️ Update the package version to `1.0.3`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openreachtech/eslint-rules-default-jest",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openreachtech/eslint-rules-default-jest",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "eslint-plugin-jest": "^28.5.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openreachtech/eslint-rules-default-jest",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A showcasing package all the Jest plugin rules of ESLint.",
   "main": "index.js",
   "exports": {


### PR DESCRIPTION
Bump the package version from `1.0.2` to `1.0.3`, in `package.json` and in the two version fields of `package-lock.json`, ahead of publishing to npmjs.

Close #47